### PR TITLE
 Change parameter handling of SequenceFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To reduce overhead and to avoid to re-invent often used patterns and helper clas
   <dd>Allows to check and run a single instance of your application.</dd>
 
   <dt>SequenceFactory</dt>
-  <dd>Simple factory to create sequences of given (array) elements.</dd>
+  <dd>Simple factory to create sequences of given elements.</dd>
 
   <dt>ThreadPool</dt>
   <dd>Small but powerful thread pool implementation.</dd>

--- a/lib/werkzeug/sequence_factory.rb
+++ b/lib/werkzeug/sequence_factory.rb
@@ -1,7 +1,7 @@
 module Werkzeug
   module SequenceFactory
     def self.loop(*array)
-      array, i = array.flatten, 0
+      i = 0
       proc do
         ret = array[i]
         i += 1
@@ -11,7 +11,7 @@ module Werkzeug
     end
 
     def self.ping_pong(*array)
-      array, i, d = array.flatten, 0, 1
+      i, d = 0, 1
       proc do
         ret = array[i]
         i += d
@@ -21,7 +21,6 @@ module Werkzeug
     end
 
     def self.random(*array)
-      array = array.flatten
       proc{ array.sample }
     end
   end

--- a/lib/werkzeug/version.rb
+++ b/lib/werkzeug/version.rb
@@ -1,3 +1,3 @@
 module Werkzeug
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/test/werkzeug/sequence_factory_test.rb
+++ b/test/werkzeug/sequence_factory_test.rb
@@ -2,41 +2,41 @@ require_relative '../test_helper'
 
 class SequenceFactoryTest < Test
   def test_loop
-    expectation = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2]
-
     subject = Werkzeug::SequenceFactory.loop(1, 2, 3, 4)
+    expectation = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2]
     assert_equal(expectation, Array.new(10, &subject))
 
-    subject = Werkzeug::SequenceFactory.loop(1, [2, 3], 4)
+    subject = Werkzeug::SequenceFactory.loop(1, [2, 3], [4])
+    expectation = [1, [2, 3], [4], 1, [2, 3], [4], 1, [2, 3], [4], 1]
     assert_equal(expectation, Array.new(10, &subject))
 
-    subject = Werkzeug::SequenceFactory.loop([1, [[2, 3], 4]])
-    assert_equal(expectation, Array.new(10, &subject))
+    subject = Werkzeug::SequenceFactory.loop
+    assert(Array.new(10, &subject).all?(&:nil?))
   end
 
   def test_ping_pong
-    expectation = [1, 2, 3, 4, 3, 2, 1, 2, 3, 4]
-
     subject = Werkzeug::SequenceFactory.ping_pong(1, 2, 3, 4)
+    expectation = [1, 2, 3, 4, 3, 2, 1, 2, 3, 4]
     assert_equal(expectation, Array.new(10, &subject))
 
     subject = Werkzeug::SequenceFactory.ping_pong(1, [2, 3], 4)
+    expectation = [1, [2, 3], 4, [2, 3], 1, [2, 3], 4, [2, 3], 1, [2, 3]]
     assert_equal(expectation, Array.new(10, &subject))
 
-    subject = Werkzeug::SequenceFactory.ping_pong([1, [[2, 3], 4]])
-    assert_equal(expectation, Array.new(10, &subject))
+    subject = Werkzeug::SequenceFactory.ping_pong
+    assert(Array.new(10, &subject).all?(&:nil?))
   end
 
   def test_random
-    expectation = [1, 2, 3, 4]
+    elements = [1, 2, 3, 4].freeze
+    subject = Werkzeug::SequenceFactory.random(*elements)
+    10.times{ assert_includes(elements, subject.call) }
 
-    subject = Werkzeug::SequenceFactory.random(1, 2, 3, 4)
-    10.times{ assert_includes(expectation, subject.call) }
+    elements = [1, [2, 3], 4].freeze
+    subject = Werkzeug::SequenceFactory.random(*elements)
+    10.times{ assert_includes(elements, subject.call) }
 
-    subject = Werkzeug::SequenceFactory.random(1, [2, 3], 4)
-    10.times{ assert_includes(expectation, subject.call) }
-
-    subject = Werkzeug::SequenceFactory.random([1, [[2, 3], 4]])
-    10.times{ assert_includes(expectation, subject.call) }
+    subject = Werkzeug::SequenceFactory.random
+    assert(Array.new(10, &subject).all?(&:nil?))
   end
 end


### PR DESCRIPTION
The SequenceFactory does not longer flatten the given elements.
This allows sequences over Arrays as elements.
(There was no real benefit to flatten given argument list.)