### PR TITLE
Add prefixed calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To reduce overhead and to avoid to re-invent often used patterns and helper clas
   <dt>PidFile</dt>
   <dd>Allows to check and run a single instance of your application.</dd>
 
+  <dt>PrefixedCalls</dt>
+  <dd>Module can be included in any class to call all methods with given prefix via `#call_all`.</dd>
+
   <dt>SequenceFactory</dt>
   <dd>Simple factory to create sequences of given elements.</dd>
 

--- a/lib/werkzeug.rb
+++ b/lib/werkzeug.rb
@@ -10,6 +10,7 @@ module Werkzeug
   autoload :ThreadPool, "#{ROOT}/thread_pool"
   autoload :SequenceFactory, "#{ROOT}/sequence_factory"
   autoload :ToolFunctions, "#{ROOT}/tool_functions"
+  autoload :PrefixedCalls, "#{ROOT}/prefixed_calls"
   autoload :VERSION, "#{ROOT}/version"
 
   def self.configure

--- a/lib/werkzeug/prefixed_calls.rb
+++ b/lib/werkzeug/prefixed_calls.rb
@@ -1,0 +1,12 @@
+module Werkzeug
+  module PrefixedCalls
+    def call_all(prefix, *args)
+      @__prefixed_methods ||= Hash.new do |h, prefix|
+        prefix = prefix.to_s
+        prefixes = [prefix, '__' + prefix, '_' + prefix]
+        h[prefix.to_sym] = methods.select{ |name| name.to_s.start_with?(*prefixes) }.sort!
+      end
+      @__prefixed_methods[prefix.to_sym].each{ |name| send(name, *args) }
+    end
+  end
+end

--- a/lib/werkzeug/version.rb
+++ b/lib/werkzeug/version.rb
@@ -1,3 +1,3 @@
 module Werkzeug
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/lib/werkzeug/version.rb
+++ b/lib/werkzeug/version.rb
@@ -1,3 +1,3 @@
 module Werkzeug
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/test/werkzeug/prefixed_calls_test.rb
+++ b/test/werkzeug/prefixed_calls_test.rb
@@ -1,0 +1,80 @@
+require_relative '../test_helper'
+
+class PrefixedCallsTest < Test
+  class TestClass
+    include Werkzeug::PrefixedCalls
+
+    attr_reader :called
+
+    def initialize
+      @called = []
+    end
+
+    alias _methods methods
+    def methods
+      @called << __method__
+      _methods
+    end
+
+    def setup
+      @called << __method__
+    end
+
+    def setup_foo
+      @called << __method__
+    end
+
+    def _setup
+      @called << __method__
+    end
+
+    def _setup_foo
+      @called << __method__
+    end
+  end
+
+  def setup
+    @subject = TestClass.new
+  end
+
+  def test_call_all
+    expected = %i[methods _setup _setup_foo setup setup_foo]
+
+    @subject.call_all(:setup)
+    assert_equal(expected, @subject.called)
+  end
+
+  def test_call_all_strings
+    expected = %i[methods _setup _setup_foo setup setup_foo]
+
+    @subject.call_all('setup')
+    assert_equal(expected, @subject.called)
+  end
+
+  def test_not_existing
+    expected = %i[methods]
+    @subject.call_all(:update)
+    assert_equal(expected, @subject.called)
+  end
+
+  def test_caching
+    expected = %i[methods _setup _setup_foo setup setup_foo _setup _setup_foo setup setup_foo]
+
+    2.times{ @subject.call_all(:setup) }
+    assert_equal(expected, @subject.called)
+  end
+
+  def test_caching_not_existing
+    expected = %i[methods]
+
+    2.times{ @subject.call_all(:update) }
+    assert_equal(expected, @subject.called)
+  end
+
+  def test_forward_arguments
+    assert_raises_message(ArgumentError, 'given 3, expected 0') do
+      @subject.call_all(:setup, 1, 2, 3)
+    end
+  end
+end
+


### PR DESCRIPTION
Module can be included in any class to call all methods with given prefix via `#call_all`.